### PR TITLE
fix(example): Add pre-created build folder in example

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -5,7 +5,6 @@ import { readFile } from 'node:fs/promises'
 (async () => {
     const content = await readFile('./Readme.md', 'utf8');
     const {result} = await transform(content, {
-        output: './build',
         plugins: [
             mermaid.transform()
         ]

--- a/example/index.js
+++ b/example/index.js
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises'
 (async () => {
     const content = await readFile('./Readme.md', 'utf8');
     const {result} = await transform(content, {
+        output: './build',
         plugins: [
             mermaid.transform()
         ]


### PR DESCRIPTION
The building of the example doesn't work without the `build` folder just after cloning the project.