### PR TITLE
fix: hide node packages for browser build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@diplodoc/mermaid-extension",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1022,9 +1022,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
-      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+      "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@doc-tools/transform": "^2.16.4",
     "@types/markdown-it": "^12.2.3",
+    "@types/node": "^20.3.2",
     "@types/react": "^18.0.35",
     "esbuild": "^0.17.12",
     "jest": "^29.5.0",

--- a/src/plugin/transform.ts
+++ b/src/plugin/transform.ts
@@ -29,16 +29,19 @@ function hidden<B extends Record<string | symbol, unknown>, F extends string | s
 }
 
 function copy(from: string, to: string) {
-    let mkdirSync, copyFileSync, dirname
-    try {
-        const fs = require('node:fs')
-        mkdirSync = fs.mkdirSync;
-        copyFileSync = fs.copyFileSync
-        dirname = require('node:path').dirname;
-    } catch(_e) {}
+    const { mkdirSync, copyFileSync } = dynrequire('node:fs');
+    const { dirname } = dynrequire('node:path');
 
     mkdirSync(dirname(to), { recursive: true });
     copyFileSync(from, to);
+}
+
+/*
+* Runtime require hidden for builders.
+* Used for nodejs api
+*/
+function dynrequire(module: string) {
+    return eval(`require('${ module }')`);
 }
 
 const registerTransforms = (md: MarkdownIt, {
@@ -65,11 +68,7 @@ const registerTransforms = (md: MarkdownIt, {
             env.meta.script.push(runtime);
 
             if (bundle) {
-                let join;
-                try {
-                    join = require('node:path').join;
-                } catch(_e) {}
-
+                const { join } = dynrequire('node:path');
                 const file = join(PACKAGE, 'runtime');
                 if (!env.bundled.has(file)) {
                     env.bundled.add(file);

--- a/src/plugin/transform.ts
+++ b/src/plugin/transform.ts
@@ -1,5 +1,3 @@
-import { join, dirname } from 'node:path';
-import { mkdirSync, copyFileSync } from 'node:fs';
 import MarkdownIt from 'markdown-it';
 import type { MarkdownItPluginCb, MarkdownItPluginOpts } from '@doc-tools/transform/lib/plugins/typings';
 import type ParserCore from 'markdown-it/lib/parser_core';
@@ -31,6 +29,14 @@ function hidden<B extends Record<string | symbol, unknown>, F extends string | s
 }
 
 function copy(from: string, to: string) {
+    let mkdirSync, copyFileSync, dirname
+    try {
+        const fs = require('node:fs')
+        mkdirSync = fs.mkdirSync;
+        copyFileSync = fs.copyFileSync
+        dirname = require('node:path').dirname;
+    } catch(_e) {}
+
     mkdirSync(dirname(to), { recursive: true });
     copyFileSync(from, to);
 }
@@ -59,6 +65,11 @@ const registerTransforms = (md: MarkdownIt, {
             env.meta.script.push(runtime);
 
             if (bundle) {
+                let join;
+                try {
+                    join = require('node:path').join;
+                } catch(_e) {}
+
                 const file = join(PACKAGE, 'runtime');
                 if (!env.bundled.has(file)) {
                     env.bundled.add(file);


### PR DESCRIPTION
Added import of node packages into a try-catch block, because extension assumes to be used on client side.