### PR TITLE
fix: remove trim at the end of mermaid code

### DIFF
--- a/src/plugin/transform.ts
+++ b/src/plugin/transform.ts
@@ -118,7 +118,7 @@ export function transform(options: Partial<PluginOptions> = {}) {
 
         md.renderer.rules.mermaid = (tokens, idx) => {
             const token = tokens[idx];
-            const code = encodeURIComponent(token.content.trim());
+            const code = encodeURIComponent(token.content.trimStart());
 
             return `<div class="mermaid" data-content="${code}"></div>`;
         };


### PR DESCRIPTION
Minimal example to reproduce:

https://mermaid.live/edit#pako:eNpVjjEOwjAMRa8SWepWLpChC70BqxcrcSGicYLrDKjq3QkgBv709fT09XcIJTJ42PjRWALPia5KGaWSWgqpkpiblRb7R-e1bBxRhgHF9XyU0zR9uXcwQmbNlGIf398Ogt04M4LvNZLeEVCO7lGzcnlKAG_aeIRWI9nvCPiF1o2PF8kyOro

If we remove `space` character in the end - it breaks because of invalid syntax