### PR TITLE
fix: navigation icon not loaded

### DIFF
--- a/esbuild/build.js
+++ b/esbuild/build.js
@@ -40,7 +40,7 @@ esbuild.build({
 esbuild.build({
     ...common,
     ...commonRuntime,
-    external: ['@gravity-ui/icons', 'd3', 'mermaid', 'ts-dedent'],
+    external: ['d3', 'mermaid', 'ts-dedent'],
     outfile: 'build/runtime/index.js',
     platform: 'neutral',
 });


### PR DESCRIPTION
Restoring the display of control icons (there was text instead of icons)