### PR TITLE
feat: added registerLayoutLoaders to ExposedAPI

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,8 +1,9 @@
-import type {InitConfig, RunOptions} from '../types';
+import type {InitConfig, LayoutLoaders, RunOptions} from '../types';
 
 import {useCallback, useEffect, useState} from 'react';
 
 export type RuntimeOptions = {
+    layoutLoaders?: LayoutLoaders;
     onError?: (error: unknown) => void;
 };
 
@@ -43,11 +44,19 @@ function omit<
 
 export function MermaidRuntime(props: InitConfig & RunOptions & RuntimeOptions) {
     const renderMermaid = useMermaid();
-    const config = omit(props as Hash, ['querySelector', 'nodes', 'nonce', 'onError']);
+    const config = omit(props as Hash, [
+        'querySelector',
+        'nodes',
+        'nonce',
+        'onError',
+        'layoutLoaders',
+    ]);
     const options = pick(props as Hash, ['querySelector', 'nodes', 'nonce']);
 
     useEffect(() => {
-        renderMermaid(config, options as Hash).catch(props.onError || (() => {}));
+        renderMermaid(config, options as Hash, props.layoutLoaders).catch(
+            props.onError || (() => {}),
+        );
     });
 
     return null;
@@ -56,8 +65,11 @@ export function MermaidRuntime(props: InitConfig & RunOptions & RuntimeOptions) 
 export function useMermaid() {
     const [mermaid, setMermaid] = useState<Parameters<Callback>[0] | null>(null);
     const render = useCallback(
-        async (config: InitConfig, options?: RunOptions) => {
+        async (config: InitConfig, options?: RunOptions, layoutLoaders?: LayoutLoaders) => {
             if (mermaid) {
+                if (layoutLoaders) {
+                    mermaid.registerLayoutLoaders(layoutLoaders);
+                }
                 mermaid.initialize(config);
                 return mermaid.run(options);
             }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -98,6 +98,7 @@ async function next(): Promise<void> {
             parseError: mermaid.parseError,
             parse: mermaid.parse,
             setParseErrorHandler: mermaid.setParseErrorHandler,
+            registerLayoutLoaders: mermaid.registerLayoutLoaders,
         } as ExposedAPI);
 
         return next();

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,10 @@ export type ExposedAPI = {
     parseError: typeof mermaid.parseError;
     parse: typeof mermaid.parse;
     setParseErrorHandler: typeof mermaid.setParseErrorHandler;
+    registerLayoutLoaders: typeof mermaid.registerLayoutLoaders;
 };
+
+export type LayoutLoaders = Parameters<typeof mermaid.registerLayoutLoaders>[0];
 
 export type ZoomOptions = {
     /**

--- a/test/runtime.spec.ts
+++ b/test/runtime.spec.ts
@@ -5,6 +5,7 @@ import type {ExposedAPI} from '../src/types';
 import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 
 const mockRender = vi.fn();
+const mockRegisterLayoutLoaders = vi.fn();
 
 vi.mock('mermaid', () => ({
     default: {
@@ -13,6 +14,7 @@ vi.mock('mermaid', () => ({
             getConfig: () => ({zoom: false}),
         },
         render: mockRender,
+        registerLayoutLoaders: mockRegisterLayoutLoaders,
     },
 }));
 
@@ -42,6 +44,7 @@ describe('Mermaid extension – runtime run()', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
         mockRender.mockReset();
+        mockRegisterLayoutLoaders.mockReset();
     });
 
     it('should render svg into element with valid data-content', async () => {
@@ -57,6 +60,13 @@ describe('Mermaid extension – runtime run()', () => {
         const svg = div.querySelector('svg');
         expect(svg).toBeTruthy();
         expect(svg!.children.length).toBeGreaterThan(0);
+    });
+
+    it('should expose registerLayoutLoaders that delegates to mermaid', () => {
+        const loaders = {elk: vi.fn()};
+        api.registerLayoutLoaders(loaders as any);
+
+        expect(mockRegisterLayoutLoaders).toHaveBeenCalledWith(loaders);
     });
 
     it('should continue rendering remaining elements when one fails', async () => {


### PR DESCRIPTION
- Added registerLayoutLoaders method to ExposedAPI, delegating directly to mermaid.registerLayoutLoaders. This allows consumers to register alternative layout engines (e.g. [ELK](https://github.com/mermaid-js/mermaid/tree/develop/packages/mermaid-layout-elk)) before rendering diagrams.
- Exported LayoutLoaders type derived from mermaid.registerLayoutLoaders signature.
- Extended RuntimeOptions in the React layer with an optional layoutLoaders prop. When provided, MermaidRuntime calls registerLayoutLoaders before initialize/run, ensuring layout engines are available for diagrams that reference them via directives (e.g. layout: elk).
- Added runtime test verifying that registerLayoutLoaders correctly delegates to the underlying Mermaid API.