### PR TITLE
fix: fixed sass plugin

### DIFF
--- a/esbuild/build.js
+++ b/esbuild/build.js
@@ -26,6 +26,7 @@ const commonRuntime = {
     loader: {
         '.svg': 'text',
     },
+    plugins: [sassPlugin({type: 'style'})],
 };
 
 build({


### PR DESCRIPTION
The mermaid diagram control buttons are drawn in JavaScript, and their positioning is handled in `zoom.scss`, which the runtime includes via `require('./zoom.scss')`. In version 2.0.0, the `inlineScss()` plugin was replaced by the default `sassPlugin()`. This plugin extracts the CSS into a separate file, and `requires('./zoom.scss')` is a dummy.